### PR TITLE
feat(api): ajout du endpoint /health avec mesure de latence

### DIFF
--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -1,0 +1,17 @@
+# api/routes/health.py
+from __future__ import annotations
+
+import time
+from fastapi import APIRouter, Request
+
+router = APIRouter(tags=["health"])
+
+@router.get("/health")
+async def health(request: Request):
+    t0 = time.perf_counter()
+
+    dt = (time.perf_counter() - t0) * 1000
+    return {
+        "status": "ok",
+        "latency_ms": round(dt, 1),
+    }


### PR DESCRIPTION
- Création du routeur FastAPI dans api/routes/health.py (tag : "health")
- Ajout du point d’accès GET /health renvoyant {"status": "ok", "latency_ms": ...}
- Utilisation de time.perf_counter() pour mesurer la latence en millisecondes